### PR TITLE
Cannot view the workspace files through Jenkins after jobs finish

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lsf/BatchSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/lsf/BatchSlave.java
@@ -60,7 +60,7 @@ public class BatchSlave extends Slave {
                 label,
                 new SSHLauncher(hostName, port, userName, 
                         Secret.toString(password), "", ""),
-                new BatchRetentionStrategy(1),
+                new BatchRetentionStrategy(24 * 60),  // 1 day
                 Collections.<NodeProperty<?>>emptyList());
         LOGGER.log(Level.INFO, "Constructing LSF slave {0}", name);
     }


### PR DESCRIPTION
This pull request is based on my experience with [sge-cloud-plugin](https://github.com/wavecomp/sge-cloud-plugin/).  I submit this untested yet well informed pull request to this project because the problem is so critical and hard to find, yet easy to fix. 

Each Jenkins project has a _Workspace_ button that you can use to view the project workspace files in your web browser.  This handy feature relies on the slave that executed the job.  However, slaves were deleted after just one minute of inactivity.  Once the slave is gone, the _Workspace_ button will no longer work.  Then the files can only be viewed using other methods like the command line.

This pull request extends the maximum idle time from one minute to one day. Slaves are are reused and if kept busy they can live a long and productive life well beyond a day.

Instead of the hard coded idle time in this pull request, in [sge-cloud-plugin](https://github.com/wavecomp/sge-cloud-plugin/) I actually added a new _Maximum idle time_ field to
_Jenkins > Manage Jenkins > Configure System > SGE Cloud_.  However, since I do not have LSF and therefore cannot test the LSF plugin, I cannot offer such an extensive fix here.  It would be relatively easy for someone who does have LSF to implement such a fix by comparing this project to [sge-cloud-plugin](https://github.com/wavecomp/sge-cloud-plugin/).
