### PR TITLE
Use SSH Credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/lsf/BatchCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/lsf/BatchCloud.java
@@ -221,6 +221,10 @@ public class BatchCloud extends Cloud {
     }
 
     public String getCredentialsId() {
+        if (credentialsId == null) {
+            SSHLauncher launcher = new SSHLauncher(getHostname(), getPort(), getUsername(), getPassword(), "", "");
+            return launcher.getCredentials().getId();
+        }
         return credentialsId;
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/lsf/BatchCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/lsf/BatchCloud/config.jelly
@@ -25,7 +25,8 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" 
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:c="/lib/credentials">
     <f:entry title="Cloud Name" field="cloudName">
         <f:textbox/>
     </f:entry>
@@ -41,11 +42,8 @@ THE SOFTWARE.
     <f:entry title="Port" field="port">
         <f:textbox clazz="required" default="22"/>
     </f:entry>
-    <f:entry title="User name" field="username">
-        <f:textbox clazz="required"/>
-    </f:entry>
-    <f:entry title="Password" field="password">
-        <f:password clazz="required"/>
+    <f:entry title="Credentials" field="credentialsId">
+        <c:select/>
     </f:entry>
 </j:jelly>
 

--- a/src/main/resources/org/jenkinsci/plugins/lsf/BatchCloud/help-credentialsId.html
+++ b/src/main/resources/org/jenkinsci/plugins/lsf/BatchCloud/help-credentialsId.html
@@ -1,0 +1,3 @@
+<div>
+    Select the credentials to be used for logging in to the remote host.
+</div>


### PR DESCRIPTION
Use ssh credentials for storing ssh username and password,
instead of storing them in cleartext in the configuration.
